### PR TITLE
Some changes to make this crate usable with a stable toolchain.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ features = ["derive", "alloc"]
 
 [dependencies.hashbrown]
 version = "0.6.3"
-features = ["nightly", "inline-more", "serde"]
+features = ["inline-more", "serde"]
 
 [features]
 use-std = ["serde/std"] # Use std instead of alloc

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 #![allow(unused_variables)]
 
+use alloc::string::String;
 use core::fmt::{Display, Formatter};
 
 use crate::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@
 //! ```
 
 #![cfg_attr(not(feature = "use-std"), no_std)]
-#![cfg_attr(not(feature = "use-std"), feature(alloc_prelude))]
 // #![deny(missing_docs)]
 #![allow(unused_imports)]
 
@@ -47,7 +46,6 @@ extern crate alloc;
 #[cfg(not(feature = "use-std"))]
 mod prelude {
     pub use alloc::format;
-    pub use alloc::prelude::v1::*;
     pub use hashbrown::HashMap;
 }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use serde::Serialize;
 
 use crate::error::{Error, Result};

--- a/src/ser/output.rs
+++ b/src/ser/output.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::ops::Index;
 use core::ops::IndexMut;
 


### PR DESCRIPTION
- Remove the "nightly" feature from dependencies.hashbrown.
- Remove the #![feature(alloc_prelude))].
- Remove pub use alloc::prelude::v1::*;
- Add some "use alloc::..." lines to compensate.

There have been no changes upstream since 2020-03-05.